### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,7 @@ evil-mail/
 │   ├── Dlls.res                  # Compiled resource file containing embedded OpenSSL DLLs
 │   ├── libeay32.dll              # OpenSSL cryptographic library (source for embedding)
 │   └── ssleay32.dll              # OpenSSL SSL/TLS library (source for embedding)
+├── CHANGELOG.md
 ├── CONTRIBUTING.md
 ├── LICENSE                       # GNU General Public License v3.0
 └── README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Changed
 
+- refreshed `.github/copilot-instructions.md` to include `CHANGELOG.md` in the repository structure tree
+
 ### Removed
 
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.